### PR TITLE
Use `void*` instead of `char*` for raw buffers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CC ?= gcc
-UFAT_CFLAGS = -O1 -Wall -Wextra -Wshadow -ggdb
+UFAT_CFLAGS = -O1 -Wall -Wextra -Wshadow -Wpedantic -ggdb
 
 all: ufat
 

--- a/README
+++ b/README
@@ -35,9 +35,8 @@ though a structure containing some key parameters and access functions:
 	    unsigned int	log2_block_size;
 	    int			(*read)(const struct ufat_device *dev, ufat_block_t start,
           ufat_block_t count, void *buffer);
-	    int			(*write)(const struct ufat_device *dev,
-					 ufat_block_t start, ufat_block_t count,
-					 const unsigned char *buffer);
+	    int			(*write)(const struct ufat_device *dev, ufat_block_t start,
+          ufat_block_t count, const void *buffer);
     };
 
 A pointer to the ``struct ufat_device`` is passed with each call to

--- a/README
+++ b/README
@@ -33,9 +33,8 @@ though a structure containing some key parameters and access functions:
 
     struct ufat_device {
 	    unsigned int	log2_block_size;
-	    int			(*read)(const struct ufat_device *dev,
-					ufat_block_t start, ufat_block_t count,
-					unsigned char *buffer);
+	    int			(*read)(const struct ufat_device *dev, ufat_block_t start,
+          ufat_block_t count, void *buffer);
 	    int			(*write)(const struct ufat_device *dev,
 					 ufat_block_t start, ufat_block_t count,
 					 const unsigned char *buffer);

--- a/README
+++ b/README
@@ -32,11 +32,11 @@ though a structure containing some key parameters and access functions:
     typedef unsigned long long ufat_block_t;
 
     struct ufat_device {
-	    unsigned int	log2_block_size;
-	    int			(*read)(const struct ufat_device *dev, ufat_block_t start,
-          ufat_block_t count, void *buffer);
-	    int			(*write)(const struct ufat_device *dev, ufat_block_t start,
-          ufat_block_t count, const void *buffer);
+      unsigned int  log2_block_size;
+      int   (*read)(const struct ufat_device *dev, ufat_block_t start,
+            ufat_block_t count, void *buffer);
+      int   (*write)(const struct ufat_device *dev, ufat_block_t start,
+            ufat_block_t count, const void *buffer);
     };
 
 A pointer to the ``struct ufat_device`` is passed with each call to
@@ -60,8 +60,8 @@ ufat_device`` for the partition/device you want to access, Use
 
     err = ufat_open(&uf, &dev);
     if (err < 0) {
-	    fprintf(stderr, "Error: %s\n", ufat_strerror(err));
-	    return -1;
+      fprintf(stderr, "Error: %s\n", ufat_strerror(err));
+      return -1;
     }
 
     /* ... */
@@ -108,8 +108,8 @@ Directories may be traversed by a series of
 slash-separated path is known, the following function is useful:
 
     int ufat_dir_find_path(struct ufat_directory *dir,
-			   const char *path, struct ufat_dirent *inf,
-			   const char **path_out);
+              const char *path, struct ufat_dirent *inf,
+              const char **path_out);
 
 Its arguments are:
 

--- a/main.c
+++ b/main.c
@@ -99,7 +99,7 @@ static int file_device_read(const struct ufat_device *dev, ufat_block_t start,
 }
 
 static int file_device_write(const struct ufat_device *dev, ufat_block_t start,
-			     ufat_block_t count, const unsigned char *buffer)
+			     ufat_block_t count, const void *buffer)
 {
 	struct file_device *f = (struct file_device *)dev;
 

--- a/main.c
+++ b/main.c
@@ -75,7 +75,7 @@ struct file_device {
 };
 
 static int file_device_read(const struct ufat_device *dev, ufat_block_t start,
-			    ufat_block_t count, unsigned char *buffer)
+			    ufat_block_t count, void *buffer)
 {
 	struct file_device *f = (struct file_device *)dev;
 

--- a/ufat.h
+++ b/ufat.h
@@ -56,9 +56,8 @@ struct ufat_device {
 	unsigned int	log2_block_size;
 	int		(*read)(const struct ufat_device *dev, ufat_block_t start,
 				ufat_block_t count, void *buffer);
-	int		(*write)(const struct ufat_device *dev,
-				 ufat_block_t start, ufat_block_t count,
-				 const unsigned char *buffer);
+	int		(*write)(const struct ufat_device *dev, ufat_block_t start,
+				ufat_block_t count, const void *buffer);
 };
 
 /* Cache parameters. The more cache is used, the fewer filesystem reads/writes

--- a/ufat.h
+++ b/ufat.h
@@ -282,7 +282,7 @@ int ufat_open_file(struct ufat *uf, struct ufat_file *f,
 		   const struct ufat_dirent *ent);
 void ufat_file_rewind(struct ufat_file *f);
 int ufat_file_advance(struct ufat_file *f, ufat_size_t nbytes);
-int ufat_file_read(struct ufat_file *f, char *buf, ufat_size_t max_size);
+int ufat_file_read(struct ufat_file *f, void *buf, ufat_size_t max_size);
 int ufat_file_write(struct ufat_file *f, const char *buf, ufat_size_t len);
 int ufat_file_truncate(struct ufat_file *f);
 

--- a/ufat.h
+++ b/ufat.h
@@ -54,9 +54,8 @@ typedef unsigned long long ufat_block_t;
  */
 struct ufat_device {
 	unsigned int	log2_block_size;
-	int		(*read)(const struct ufat_device *dev,
-				ufat_block_t start, ufat_block_t count,
-				unsigned char *buffer);
+	int		(*read)(const struct ufat_device *dev, ufat_block_t start,
+				ufat_block_t count, void *buffer);
 	int		(*write)(const struct ufat_device *dev,
 				 ufat_block_t start, ufat_block_t count,
 				 const unsigned char *buffer);

--- a/ufat.h
+++ b/ufat.h
@@ -283,7 +283,7 @@ int ufat_open_file(struct ufat *uf, struct ufat_file *f,
 void ufat_file_rewind(struct ufat_file *f);
 int ufat_file_advance(struct ufat_file *f, ufat_size_t nbytes);
 int ufat_file_read(struct ufat_file *f, void *buf, ufat_size_t max_size);
-int ufat_file_write(struct ufat_file *f, const char *buf, ufat_size_t len);
+int ufat_file_write(struct ufat_file *f, const void *buf, ufat_size_t len);
 int ufat_file_truncate(struct ufat_file *f);
 
 /* Filesystem creation */

--- a/ufat_file.c
+++ b/ufat_file.c
@@ -368,7 +368,7 @@ static int write_blocks(struct ufat_file *f, const char *buf, ufat_size_t size)
 	return requested_blocks << log2_block_size;
 }
 
-int ufat_file_write(struct ufat_file *f, const char *buf, ufat_size_t len)
+int ufat_file_write(struct ufat_file *f, const void *buf, ufat_size_t len)
 {
 	const ufat_size_t max_write = ~f->cur_pos;
 	ufat_size_t total;
@@ -383,7 +383,7 @@ int ufat_file_write(struct ufat_file *f, const char *buf, ufat_size_t len)
 	if (i < 0)
 		return i;
 
-	buf += i;
+	buf = (const char*)buf + i;
 	len -= i;
 
 	/* Write complete blocks */
@@ -396,7 +396,7 @@ int ufat_file_write(struct ufat_file *f, const char *buf, ufat_size_t len)
 		if (!i)
 			break;
 
-		buf += i;
+		buf = (const char*)buf + i;
 		len -= i;
 	}
 

--- a/ufat_file.c
+++ b/ufat_file.c
@@ -354,8 +354,7 @@ static int write_blocks(struct ufat_file *f, const char *buf, ufat_size_t size)
 	if (i < 0)
 		return i;
 
-	i = uf->dev->write(uf->dev, starting_block, requested_blocks,
-			   (const uint8_t *)buf);
+	i = uf->dev->write(uf->dev, starting_block, requested_blocks, buf);
 	if (i < 0)
 		return -UFAT_ERR_IO;
 

--- a/ufat_file.c
+++ b/ufat_file.c
@@ -218,9 +218,6 @@ int ufat_file_read(struct ufat_file *f, void *buf, ufat_size_t size)
 	if (len < 0)
 		return len;
 
-	buf = (char*)buf + len;
-	size -= len;
-
 	return total;
 }
 

--- a/ufat_file.c
+++ b/ufat_file.c
@@ -168,8 +168,7 @@ static int read_blocks(struct ufat_file *f, char *buf, ufat_size_t size)
 	if (i < 0)
 		return i;
 
-	i = uf->dev->read(uf->dev, starting_block, requested_blocks,
-			  (uint8_t *)buf);
+	i = uf->dev->read(uf->dev, starting_block, requested_blocks, buf);
 	if (i < 0)
 		return -UFAT_ERR_IO;
 

--- a/ufat_file.c
+++ b/ufat_file.c
@@ -182,7 +182,7 @@ static int read_blocks(struct ufat_file *f, char *buf, ufat_size_t size)
 	return requested_blocks << log2_block_size;
 }
 
-int ufat_file_read(struct ufat_file *f, char *buf, ufat_size_t size)
+int ufat_file_read(struct ufat_file *f, void *buf, ufat_size_t size)
 {
 	ufat_size_t total;
 	int len;
@@ -196,7 +196,7 @@ int ufat_file_read(struct ufat_file *f, char *buf, ufat_size_t size)
 	if (len < 0)
 		return len;
 
-	buf += len;
+	buf = (char*)buf + len;
 	size -= len;
 
 	/* Read contiguous blocks within a cluster */
@@ -209,7 +209,7 @@ int ufat_file_read(struct ufat_file *f, char *buf, ufat_size_t size)
 		if (!ret)
 			break;
 
-		buf += ret;
+		buf = (char*)buf + len;
 		size -= ret;
 	}
 
@@ -218,7 +218,7 @@ int ufat_file_read(struct ufat_file *f, char *buf, ufat_size_t size)
 	if (len < 0)
 		return len;
 
-	buf += len;
+	buf = (char*)buf + len;
 	size -= len;
 
 	return total;


### PR DESCRIPTION
Use of `void*` is more common for raw buffers (for example `memcpy()`, `fread()`/`fwrite()` or `read()`/`write()` from standard libraries). In C++ it is also easier to use `void*` because any pointer can be implicitly converted to `void*`, while conversion to `char*` requires explicit cast.

This change comes with a small cost that pointer arithmetic is more complicated. C/C++ standards forbid any arithmetic on `void*`. GCC (and possibly other compilers) allows it as an extension - this can be switched off with `-Wpedantic`.