### PR TITLE
Fix bug in ufat_file_read()

### DIFF
--- a/ufat_file.c
+++ b/ufat_file.c
@@ -201,16 +201,16 @@ int ufat_file_read(struct ufat_file *f, void *buf, ufat_size_t size)
 
 	/* Read contiguous blocks within a cluster */
 	for (;;) {
-		int ret = read_blocks(f, buf, size);
+		len = read_blocks(f, buf, size);
 
-		if (ret < 0)
-			return ret;
+		if (len < 0)
+			return len;
 
-		if (!ret)
+		if (!len)
 			break;
 
 		buf = (char*)buf + len;
-		size -= ret;
+		size -= len;
 	}
 
 	/* Read remaining block fragment */


### PR DESCRIPTION
In inner loop the number of read bytes was assigned to `ret`, however
the buffer was shifted by `len` bytes, where `len` was set before the
loop. This causes all kinds of strange issues when reading data.

Fixes #8