### PR TITLE
mkfs improvements - round 2

### DIFF
--- a/ufat_mkfs.c
+++ b/ufat_mkfs.c
@@ -434,17 +434,9 @@ static int init_root_cluster(struct ufat_device *dev,
 {
 	const ufat_block_t cluster_start =
 		fl->fat_blocks * 2 + fl->reserved_blocks + fl->root_blocks;
-	const unsigned int block_size = 1 << dev->log2_block_size;
 	const unsigned int cluster_blocks = 1 << fl->log2_bpc;
-	uint8_t buf[block_size];
-	ufat_block_t i;
 
-	memset(buf, 0, block_size);
-	for (i = 0; i < cluster_blocks; i++)
-		if (dev->write(dev, cluster_start + i, 1, buf) < 0)
-			return -UFAT_ERR_IO;
-
-	return 0;
+	return erase_blocks(dev, cluster_start, cluster_blocks);
 }
 
 int ufat_mkfs(struct ufat_device *dev, ufat_block_t nblk)

--- a/ufat_mkfs.c
+++ b/ufat_mkfs.c
@@ -250,9 +250,12 @@ static int write_bpb(struct ufat_device *dev, const struct fs_layout *fl)
 		memcpy(buf + 0x052, type_name, 8);
 	}
 
-	/* Write boot sector and backup */
-	if (dev->write(dev, 0, 1, buf) < 0 ||
-	    dev->write(dev, backup, 1, buf) < 0)
+	/* Write boot sector */
+	if (dev->write(dev, 0, 1, buf) < 0)
+		return -UFAT_ERR_IO;
+
+	/* Write backup of boot sector in case of FAT32 */
+	if (fl->type == UFAT_TYPE_FAT32 && dev->write(dev, backup, 1, buf) < 0)
 		return -UFAT_ERR_IO;
 
 	return 0;

--- a/ufat_mkfs.c
+++ b/ufat_mkfs.c
@@ -425,16 +425,8 @@ static int init_root_blocks(struct ufat_device *dev, const struct fs_layout *fl)
 {
 	const ufat_block_t root_start =
 		fl->fat_blocks * 2 + fl->reserved_blocks;
-	const unsigned int block_size = 1 << dev->log2_block_size;
-	uint8_t buf[block_size];
-	ufat_block_t i;
 
-	memset(buf, 0, block_size);
-	for (i = 0; i < fl->root_blocks; i++)
-		if (dev->write(dev, root_start + i, 1, buf) < 0)
-			return -UFAT_ERR_IO;
-
-	return 0;
+	return erase_blocks(dev, root_start, fl->root_blocks);
 }
 
 static int init_root_cluster(struct ufat_device *dev,

--- a/ufat_mkfs.c
+++ b/ufat_mkfs.c
@@ -413,10 +413,6 @@ int ufat_mkfs(struct ufat_device *dev, ufat_block_t nblk)
 	if (err < 0)
 		return err;
 
-	err = write_bpb(dev, &fl);
-	if (err < 0)
-		return err;
-
 	switch (fl.type) {
 	case UFAT_TYPE_FAT12:
 		err = init_fat12(dev, &fl);
@@ -435,7 +431,12 @@ int ufat_mkfs(struct ufat_device *dev, ufat_block_t nblk)
 		return err;
 
 	if (fl.type == UFAT_TYPE_FAT32)
-		return init_root_cluster(dev, &fl);
+		err = init_root_cluster(dev, &fl);
+	else
+		err = init_root_blocks(dev, &fl);
 
-	return init_root_blocks(dev, &fl);
+	if (err < 0)
+		return err;
+
+	return write_bpb(dev, &fl);
 }


### PR DESCRIPTION
Various mkfs-related improvements:
- reduce the chance of producing a file system which appears to be correct, but in fact isn't, because the format operation was interrupted in the middle,
- write backup of BPB only for FAT32,
- use recommended number of reserved sectors,
- use recommended sector for BPB backup,
- fix bug related to "blocks per sector",
- write FSInfo in case of FAT32,
- reduce code duplication by introducing an `erase_blocks()` and using it where appropriate.

FAT32 file system produced by `ufat_mkfs()` after these changes is functionally identical to what `mkfs.fat` produces on Linux and passes the check of `fsck.fat` with zero errors/warnings.